### PR TITLE
Tokenized public report links (/r/[token])

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -33,9 +33,11 @@ export async function middleware(request: NextRequest) {
   const isAuthPage = pathname === '/login' || pathname === '/signup'
   const isOnboardingPage = pathname.startsWith('/onboarding')
   const isApiRoute = pathname.startsWith('/api')
+  // Public tokenized report pages (/r/[token]) — no login required
+  const isPublicReportPage = pathname.startsWith('/r/')
 
-  // Unauthenticated: redirect to login (except auth pages and API routes)
-  if (!user && !isAuthPage && !isApiRoute) {
+  // Unauthenticated: redirect to login (except auth pages, API routes, public report pages)
+  if (!user && !isAuthPage && !isApiRoute && !isPublicReportPage) {
     const url = request.nextUrl.clone()
     url.pathname = '/login'
     return NextResponse.redirect(url)
@@ -48,8 +50,8 @@ export async function middleware(request: NextRequest) {
     return NextResponse.redirect(url)
   }
 
-  // Authenticated on a portal page (not onboarding, not API): check if onboarding is needed
-  if (user && !isAuthPage && !isOnboardingPage && !isApiRoute) {
+  // Authenticated on a portal page (not onboarding, not API, not public report): check if onboarding is needed
+  if (user && !isAuthPage && !isOnboardingPage && !isApiRoute && !isPublicReportPage) {
     const { data: progress } = await supabase
       .from('onboarding_progress')
       .select('is_complete, current_step')

--- a/src/app/(portal)/reports/reports-client.tsx
+++ b/src/app/(portal)/reports/reports-client.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useState } from 'react'
+import { toast } from 'sonner'
 import { motion, AnimatePresence } from 'framer-motion'
 import {
   FileText,
@@ -255,6 +256,23 @@ interface ReportModalProps {
 }
 
 function ReportModal({ report, onClose }: ReportModalProps) {
+  const [sharing, setSharing] = useState(false)
+
+  async function handleShare() {
+    setSharing(true)
+    try {
+      const res = await fetch(`/api/reports/${report.id}/share`, { method: 'POST' })
+      if (!res.ok) throw new Error(`HTTP ${res.status}`)
+      const { url } = (await res.json()) as { url: string }
+      await navigator.clipboard.writeText(url)
+      toast.success('Public report link copied to clipboard')
+    } catch {
+      toast.error('Could not create a share link for this report')
+    } finally {
+      setSharing(false)
+    }
+  }
+
   return (
     <motion.div
       initial={{ opacity: 0 }}
@@ -360,9 +378,14 @@ function ReportModal({ report, onClose }: ReportModalProps) {
             <Download className="w-4 h-4" />
             Download PDF
           </Button>
-          <Button variant="outline" className="flex-1 rounded-xl border-border gap-2">
+          <Button
+            variant="outline"
+            className="flex-1 rounded-xl border-border gap-2"
+            onClick={handleShare}
+            disabled={sharing}
+          >
             <Share2 className="w-4 h-4" />
-            Share with Team
+            {sharing ? 'Creating link...' : 'Copy Public Link'}
           </Button>
         </div>
       </motion.div>

--- a/src/app/api/reports/[reportId]/share/route.ts
+++ b/src/app/api/reports/[reportId]/share/route.ts
@@ -1,0 +1,100 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { randomUUID } from 'crypto'
+import { createClient } from '@/lib/supabase/server'
+import { createAdminClient } from '@/lib/supabase/admin'
+import { getCurrentOrgId } from '@/lib/supabase/helpers'
+import { portal } from '@/lib/logger'
+
+export const runtime = 'nodejs'
+export const dynamic = 'force-dynamic'
+
+interface RouteParams {
+  params: Promise<{ reportId: string }>
+}
+
+/**
+ * Loads the report for the logged-in user's org, or null if the user is not
+ * authenticated, has no org, or the report belongs to another org.
+ * Uses the session client, so RLS also enforces org scoping.
+ */
+async function getAuthorizedReport(reportId: string) {
+  const supabase = await createClient()
+  const orgId = await getCurrentOrgId(supabase)
+  if (!orgId) return null
+
+  const { data: report } = await supabase
+    .from('reports')
+    .select('id, org_id, share_token')
+    .eq('id', reportId)
+    .eq('org_id', orgId)
+    .maybeSingle()
+
+  return report as { id: string; org_id: string; share_token: string | null } | null
+}
+
+/**
+ * POST /api/reports/[reportId]/share
+ *
+ * Generates (or returns the existing) share token for a report and responds
+ * with the public URL. Auth: portal session, report must belong to the
+ * caller's org. Idempotent: repeated calls return the same link.
+ */
+export async function POST(request: NextRequest, { params }: RouteParams) {
+  const { reportId } = await params
+  const report = await getAuthorizedReport(reportId)
+
+  if (!report) {
+    return NextResponse.json({ error: 'Report not found' }, { status: 404 })
+  }
+
+  let token = report.share_token
+  if (!token) {
+    token = randomUUID()
+    // RLS has no UPDATE policy on reports for members — write via service role
+    // after the org-scoped select above proved authorization.
+    const admin = createAdminClient()
+    const { error } = await admin
+      .from('reports')
+      .update({ share_token: token })
+      .eq('id', report.id)
+
+    if (error) {
+      console.error('[reports/share] token update failed:', error.message)
+      return NextResponse.json({ error: 'Failed to create share link' }, { status: 500 })
+    }
+  }
+
+  const url = `${request.nextUrl.origin}/r/${token}`
+  portal.api('POST', 'reports.share', 200, 0, { metadata: { reportId } })
+  return NextResponse.json({ token, url })
+}
+
+/**
+ * DELETE /api/reports/[reportId]/share
+ *
+ * Revokes a report's share token. The old public URL 404s immediately.
+ */
+export async function DELETE(request: NextRequest, { params }: RouteParams) {
+  const { reportId } = await params
+  const report = await getAuthorizedReport(reportId)
+
+  if (!report) {
+    return NextResponse.json({ error: 'Report not found' }, { status: 404 })
+  }
+
+  if (report.share_token) {
+    const admin = createAdminClient()
+    const { error } = await admin
+      .from('reports')
+      .update({ share_token: null })
+      .eq('id', report.id)
+
+    if (error) {
+      console.error('[reports/share] token revoke failed:', error.message)
+      return NextResponse.json({ error: 'Failed to revoke share link' }, { status: 500 })
+    }
+  }
+
+  portal.api('DELETE', 'reports.share', 200, 0, { metadata: { reportId } })
+  return NextResponse.json({ success: true })
+}

--- a/src/app/r/[token]/page.tsx
+++ b/src/app/r/[token]/page.tsx
@@ -1,0 +1,252 @@
+import type { Metadata } from 'next'
+import { notFound } from 'next/navigation'
+import {
+  FileText,
+  TrendingUp,
+  TrendingDown,
+  Minus,
+  CheckCircle2,
+  Search,
+  Users,
+  Megaphone,
+} from 'lucide-react'
+import { createAdminClient } from '@/lib/supabase/admin'
+import { cn } from '@/lib/utils'
+
+// Public tokenized report page. Always fetched fresh so revoked tokens 404 immediately.
+export const dynamic = 'force-dynamic'
+
+export const metadata: Metadata = {
+  title: 'Performance Report',
+  robots: { index: false, follow: false },
+}
+
+// ===== Types =====
+
+interface PublicMetric {
+  label: string
+  value: number
+  prevValue: number | null
+  suffix?: string
+  decimals?: number
+  lowerIsBetter?: boolean
+  icon: React.ElementType
+}
+
+// ===== Helpers (mirrors reports-client.tsx trend logic) =====
+
+function getTrend(value: number, prevValue: number, lowerIsBetter = false): 'up' | 'down' | 'flat' {
+  const diff = value - prevValue
+  if (Math.abs(diff) < 0.01) return 'flat'
+  const isPositive = lowerIsBetter ? diff < 0 : diff > 0
+  return isPositive ? 'up' : 'down'
+}
+
+function getChangePercent(value: number, prevValue: number): string | null {
+  if (prevValue === 0) return null
+  const pct = Math.abs(((value - prevValue) / prevValue) * 100)
+  return pct.toFixed(1) + '%'
+}
+
+function prevFromChangePct(value: number, changePct: number | undefined): number | null {
+  if (changePct === undefined || changePct === null) return null
+  if (changePct === 0) return value
+  return Math.round(value / (1 + changePct / 100))
+}
+
+function formatValue(value: number, decimals = 0): string {
+  return decimals > 0
+    ? value.toFixed(decimals)
+    : value.toLocaleString('en-US')
+}
+
+// ===== Page =====
+
+interface PublicReportPageProps {
+  params: Promise<{ token: string }>
+}
+
+export default async function PublicReportPage({ params }: PublicReportPageProps) {
+  const { token } = await params
+  if (!token || token.length < 8) notFound()
+
+  // Service-role client (server-only): reports are only reachable here when a
+  // share_token has been explicitly generated for them.
+  const supabase = createAdminClient()
+  const { data: report } = await supabase
+    .from('reports')
+    .select('*, organizations(name)')
+    .eq('share_token', token)
+    .maybeSingle()
+
+  if (!report) notFound()
+
+  const org = report.organizations as { name: string } | null
+  const orgName = org?.name ?? 'Your Business'
+  const m = (report.metrics as Record<string, number>) ?? {}
+  const highlights = ((report.highlights as Array<string | Record<string, unknown>>) ?? [])
+    .filter((h): h is string => typeof h === 'string')
+
+  const periodEnd = new Date(report.period_end + 'T00:00:00')
+  const periodStart = new Date(report.period_start + 'T00:00:00')
+  const isMonthly = report.report_type === 'monthly'
+  const periodLabel = isMonthly
+    ? periodEnd.toLocaleDateString('en-US', { month: 'long', year: 'numeric' })
+    : `${periodStart.toLocaleDateString('en-US', { month: 'short', day: 'numeric' })} to ${periodEnd.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })}`
+  const comparisonLabel = isMonthly ? 'last month' : 'last week'
+  const dateGenerated = new Date(report.created_at).toLocaleDateString('en-US', {
+    month: 'long',
+    day: 'numeric',
+    year: 'numeric',
+  })
+
+  const metrics: PublicMetric[] = [
+    {
+      label: 'Google Search Clicks',
+      value: m.clicks ?? 0,
+      prevValue: prevFromChangePct(m.clicks ?? 0, m.clicks_change_pct),
+      icon: Search,
+    },
+    {
+      label: 'Website Visits',
+      value: m.sessions ?? 0,
+      prevValue: prevFromChangePct(m.sessions ?? 0, m.sessions_change_pct),
+      icon: TrendingUp,
+    },
+    {
+      label: 'Avg. Google Position',
+      value: m.avg_position ?? 0,
+      prevValue: m.position_change ? (m.avg_position ?? 0) + m.position_change : null,
+      decimals: 1,
+      lowerIsBetter: true,
+      icon: Users,
+    },
+    {
+      label: 'Phone Calls',
+      value: m.phone_calls ?? 0,
+      prevValue: null,
+      icon: Megaphone,
+    },
+  ]
+
+  return (
+    <div className="min-h-screen bg-background">
+      <div className="px-4 py-8 md:py-12 max-w-2xl mx-auto">
+        {/* Header */}
+        <div className="flex items-start gap-3 mb-6">
+          <div className="w-12 h-12 rounded-xl bg-strawberry/10 flex items-center justify-center shrink-0">
+            <FileText className="w-6 h-6 text-strawberry" />
+          </div>
+          <div className="min-w-0">
+            <p className="text-xs font-medium text-strawberry uppercase tracking-wide mb-0.5">
+              {isMonthly ? 'Monthly' : 'Weekly'} Performance Report · {periodLabel}
+            </p>
+            <h1 className="text-xl sm:text-2xl font-nunito font-bold text-foreground">
+              {orgName}
+            </h1>
+            <p className="text-xs text-muted-foreground mt-1">
+              Prepared by Skooped · Generated {dateGenerated}
+            </p>
+          </div>
+        </div>
+
+        {/* Summary */}
+        {report.summary && (
+          <div className="rounded-lg md:rounded-2xl border border-border bg-card p-4 md:p-6 mb-6">
+            <h2 className="text-sm font-medium text-foreground mb-2">The short version</h2>
+            <p className="text-sm text-muted-foreground leading-relaxed">{report.summary}</p>
+          </div>
+        )}
+
+        {/* Metrics */}
+        <div className="rounded-lg md:rounded-2xl border border-border bg-card p-4 md:p-6 mb-6">
+          <h2 className="text-sm font-medium text-foreground mb-4">
+            How your marketing did vs. {comparisonLabel}
+          </h2>
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+            {metrics.map((metric) => {
+              const Icon = metric.icon
+              const hasPrev = metric.prevValue !== null
+              const trend = hasPrev
+                ? getTrend(metric.value, metric.prevValue as number, metric.lowerIsBetter)
+                : 'flat'
+              const pct = hasPrev ? getChangePercent(metric.value, metric.prevValue as number) : null
+              return (
+                <div key={metric.label} className="rounded-xl bg-background border border-border p-4">
+                  <div className="flex items-center gap-2 mb-3">
+                    <div className="w-7 h-7 rounded-lg bg-strawberry/10 flex items-center justify-center">
+                      <Icon className="w-3.5 h-3.5 text-strawberry" />
+                    </div>
+                    <span className="text-xs text-muted-foreground">{metric.label}</span>
+                  </div>
+                  <div className="flex items-end justify-between">
+                    <div>
+                      <span className="text-2xl font-nunito font-bold text-foreground">
+                        {formatValue(metric.value, metric.decimals)}
+                        {metric.suffix ?? ''}
+                      </span>
+                      {hasPrev && (
+                        <p className="text-[11px] text-muted-foreground mt-0.5">
+                          vs. {formatValue(metric.prevValue as number, metric.decimals)} {comparisonLabel}
+                        </p>
+                      )}
+                    </div>
+                    {pct && (
+                      <span
+                        className={cn(
+                          'text-xs font-semibold flex items-center gap-1 px-2 py-1 rounded-lg',
+                          trend === 'up'
+                            ? 'bg-mint/10 text-mint'
+                            : trend === 'down'
+                              ? 'bg-strawberry/10 text-strawberry'
+                              : 'bg-muted text-muted-foreground',
+                        )}
+                      >
+                        {trend === 'up' && <TrendingUp className="w-3 h-3" />}
+                        {trend === 'down' && <TrendingDown className="w-3 h-3" />}
+                        {trend === 'flat' && <Minus className="w-3 h-3" />}
+                        {pct}
+                      </span>
+                    )}
+                  </div>
+                </div>
+              )
+            })}
+          </div>
+        </div>
+
+        {/* Highlights */}
+        {highlights.length > 0 && (
+          <div className="rounded-lg md:rounded-2xl border border-border bg-card p-4 md:p-6 mb-6">
+            <h2 className="text-sm font-medium text-foreground mb-3">Wins this period</h2>
+            <ul className="space-y-2">
+              {highlights.map((h, i) => (
+                <li key={i} className="flex items-start gap-2 text-sm text-muted-foreground">
+                  <CheckCircle2 className="w-4 h-4 text-mint shrink-0 mt-0.5" />
+                  {h}
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+
+        {/* Footer */}
+        <div className="text-center pt-2 pb-6">
+          <p className="text-xs text-muted-foreground">
+            Prepared for {orgName} by{' '}
+            <a
+              href="https://skooped.io"
+              className="font-medium text-strawberry hover:text-strawberry/80 transition-colors"
+            >
+              Skooped
+            </a>
+            , your AI-powered marketing team.
+          </p>
+          <p className="text-[11px] text-muted-foreground/70 mt-1">
+            This is a private report link, please don&apos;t share it publicly.
+          </p>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/supabase/APPLY-ORDER.md
+++ b/supabase/APPLY-ORDER.md
@@ -1,0 +1,45 @@
+# Applying the migrations to Supabase project `btwrcfzphkwrvcqoyhym`
+
+The live DB is empty except a legacy 1-row `public.clients` table (no code
+references it). No migration has ever been applied. Apply all four files via
+the SQL editor (https://supabase.com/dashboard/project/btwrcfzphkwrvcqoyhym/sql/new),
+one file per run, in exactly this order:
+
+| # | File | What it creates | Idempotent? |
+|---|------|-----------------|-------------|
+| 1 | `migrations/20260314000000_base_schema.sql` | organizations, organization_members, profiles, business_profiles, subscriptions, contact_submissions, clients (guarded), `update_updated_at_column()`, `user_org_ids()`, RLS | **Yes** — every statement guarded (`IF NOT EXISTS` / `DROP ... IF EXISTS`). Never drops or modifies existing rows; the live `clients` table survives untouched apart from `ENABLE ROW LEVEL SECURITY` |
+| 2 | `migrations/20260315000000_onboarding_oauth.sql` | onboarding_progress, oauth_connections, triggers, RLS | **No** — bare `CREATE TABLE` / `CREATE INDEX` / `CREATE POLICY` / `CREATE TRIGGER`; a second run fails on the first `CREATE TABLE`. Run once |
+| 3 | `migrations/20260323000000_metric_tables.sql` | seo/analytics/gbp/ads/social metrics, agent_activity, site_deployments, content_posts, reports, RLS | **Partial** — tables and indexes are `IF NOT EXISTS`, but the `CREATE POLICY` statements are not guarded; a second run fails at the first policy. Run once |
+| 4 | `migrations/20260728000000_report_share_tokens.sql` | `reports.share_token` column + partial unique index | **Yes** — `ADD COLUMN IF NOT EXISTS` + `CREATE UNIQUE INDEX IF NOT EXISTS` |
+
+Order matters: 2 and 3 both have FKs and policies against
+`organizations(id)` / `organization_members`, created only by 1.
+4 alters `reports`, created only by 3.
+
+## Notes
+
+- **Concatenation:** you can also paste all four files into a single SQL-editor
+  run in the order above; each file is a plain SQL script with no `BEGIN/COMMIT`
+  of its own (the editor wraps the run in one transaction, so a failure rolls
+  back everything — safe).
+- **`clients` lockdown:** step 1 enables RLS on `public.clients` with no
+  policies. The portal never touches that table; only the service-role key can
+  read it afterward. If some external consumer reads `clients` with the anon
+  key, delete that one `ALTER TABLE public.clients ENABLE ROW LEVEL SECURITY;`
+  line before running.
+- **20260315 fix included:** its two `oauth_connections` policies originally
+  selected `organization_id` from `organization_members` — a column that never
+  existed anywhere (code and 20260323 use `org_id`). Fixed in the same commit
+  that adds the base schema; without the fix, step 2 fails at
+  `CREATE POLICY "Org members can view oauth connections"`.
+- **Service role:** signup, onboarding inserts, the contact endpoint, and all
+  cron/agent routes use the service-role client and bypass RLS. RLS policies
+  only cover the browser-session (user) client's reads/updates.
+- **Known app gap (not fixed here):** `src/app/api/stripe/webhook/route.ts`
+  writes `subscriptions` with the cookie-based server client; in a webhook
+  context there is no session, so RLS will block the upsert. The route should
+  use `createAdminClient()`. Schema matches the route's own DDL comment either
+  way.
+- **Seeding test data:** after all four migrations, `scripts/seed-test-metrics.sql`
+  seeds 30 days of metrics for a hard-coded org id — insert an `organizations`
+  row with that id first, or edit `oid` at the top of the script.

--- a/supabase/migrations/20260314000000_base_schema.sql
+++ b/supabase/migrations/20260314000000_base_schema.sql
@@ -1,0 +1,265 @@
+-- ============================================================================
+-- Skooped.io — Base Schema (organizations, membership, profiles, business
+-- profiles, subscriptions, contact submissions, legacy clients)
+-- Date: 2026-03-14 (timestamped BEFORE all other migrations so the chain
+--       orders correctly: every later migration references organizations(id))
+--
+-- Derived strictly from what the app code reads/writes:
+--   * signup:   src/app/(auth)/signup/actions.ts        (profiles, organizations,
+--               organization_members, onboarding_progress inserts — admin client)
+--   * org lookup: src/lib/supabase/helpers.ts getCurrentOrgId()
+--               → organization_members(org_id, user_id), .single() per user
+--   * business_profiles: onboarding actions, settings action/page, website page,
+--               agents custom-prompt (reads primary_color / font_style with fallbacks)
+--   * subscriptions: DDL comment at top of src/app/api/stripe/webhook/route.ts
+--               (reproduced verbatim below)
+--   * contact_submissions: src/app/api/contact/route.ts (insert, admin) +
+--               src/app/(portal)/messages/page.tsx (select, user client)
+--   * clients: legacy live table (1 row) — NOT referenced anywhere in code;
+--               guarded create only, so an existing table survives untouched.
+--
+-- Idempotent: safe to re-run (IF NOT EXISTS / DROP ... IF EXISTS guards).
+-- ============================================================================
+
+-- ─── updated_at trigger function ─────────────────────────────────────────────
+-- (20260315 re-creates this with CREATE OR REPLACE; identical body, harmless)
+
+CREATE OR REPLACE FUNCTION update_updated_at_column()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = NOW();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- ─── organizations ───────────────────────────────────────────────────────────
+-- Columns: signup inserts name/slug/owner_id/plan/status; getCurrentOrg selects *.
+
+CREATE TABLE IF NOT EXISTS public.organizations (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  name text NOT NULL,
+  slug text NOT NULL UNIQUE,
+  owner_id uuid REFERENCES auth.users(id) ON DELETE SET NULL,
+  plan text NOT NULL DEFAULT 'starter',
+  status text NOT NULL DEFAULT 'active',
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+DROP TRIGGER IF EXISTS update_organizations_updated_at ON public.organizations;
+CREATE TRIGGER update_organizations_updated_at
+  BEFORE UPDATE ON public.organizations
+  FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+
+-- ─── organization_members (the membership mechanism) ─────────────────────────
+-- getCurrentOrgId() does .select('org_id').eq('user_id', uid).single()
+-- → exactly one membership per user is assumed (also by the Stripe webhook),
+--   enforced with a UNIQUE index on user_id.
+
+CREATE TABLE IF NOT EXISTS public.organization_members (
+  org_id uuid NOT NULL REFERENCES public.organizations(id) ON DELETE CASCADE,
+  user_id uuid NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  role text NOT NULL DEFAULT 'member',
+  created_at timestamptz NOT NULL DEFAULT now(),
+  PRIMARY KEY (org_id, user_id)
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS uq_organization_members_user
+  ON public.organization_members(user_id);
+
+-- ─── membership helper (SECURITY DEFINER) ────────────────────────────────────
+-- A SELECT policy on organization_members cannot subquery itself (infinite
+-- recursion). This definer function bypasses RLS for that one lookup and is
+-- also usable by any policy that needs "orgs the current user belongs to".
+
+CREATE OR REPLACE FUNCTION public.user_org_ids()
+RETURNS SETOF uuid
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path = public
+STABLE
+AS $$
+  SELECT org_id FROM public.organization_members WHERE user_id = auth.uid();
+$$;
+
+-- ─── profiles ────────────────────────────────────────────────────────────────
+-- Shape from src/lib/types.ts Profile; signup inserts (id, full_name) via admin.
+-- Read with the USER client in portal layout, dashboard, settings (own row and
+-- co-members' rows for the team list).
+
+CREATE TABLE IF NOT EXISTS public.profiles (
+  id uuid PRIMARY KEY REFERENCES auth.users(id) ON DELETE CASCADE,
+  full_name text,
+  phone text,
+  timezone text,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+DROP TRIGGER IF EXISTS update_profiles_updated_at ON public.profiles;
+CREATE TRIGGER update_profiles_updated_at
+  BEFORE UPDATE ON public.profiles
+  FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+
+-- ─── business_profiles ───────────────────────────────────────────────────────
+-- One row per org (all code paths do .eq('org_id', ...).single() / update).
+-- Columns = src/lib/types.ts BusinessProfile + template (onboarding step 1)
+-- + primary_color / font_style (read by agents custom-prompt with fallbacks).
+
+CREATE TABLE IF NOT EXISTS public.business_profiles (
+  org_id uuid PRIMARY KEY REFERENCES public.organizations(id) ON DELETE CASCADE,
+  business_name text NOT NULL DEFAULT '',
+  industry text,
+  template text,
+  services text[],
+  service_areas text[],
+  phone text,
+  email text,
+  website_url text,
+  city text,
+  state text,
+  description text,
+  primary_color text,
+  font_style text,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+DROP TRIGGER IF EXISTS update_business_profiles_updated_at ON public.business_profiles;
+CREATE TRIGGER update_business_profiles_updated_at
+  BEFORE UPDATE ON public.business_profiles
+  FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+
+-- ─── subscriptions ───────────────────────────────────────────────────────────
+-- Verbatim from the DDL comment in src/app/api/stripe/webhook/route.ts.
+
+CREATE TABLE IF NOT EXISTS public.subscriptions (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  org_id uuid NOT NULL REFERENCES public.organizations(id) ON DELETE CASCADE,
+  user_id uuid NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  stripe_subscription_id text NOT NULL UNIQUE,
+  stripe_customer_id text NOT NULL,
+  plan text NOT NULL,
+  status text NOT NULL,
+  trial_end timestamptz,
+  billing_cycle_anchor timestamptz,
+  cancel_at timestamptz,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS subscriptions_org_id_idx ON public.subscriptions(org_id);
+CREATE INDEX IF NOT EXISTS subscriptions_user_id_idx ON public.subscriptions(user_id);
+CREATE INDEX IF NOT EXISTS subscriptions_stripe_subscription_id_idx ON public.subscriptions(stripe_subscription_id);
+
+-- ─── contact_submissions ─────────────────────────────────────────────────────
+-- Insert shape from src/app/api/contact/route.ts (admin client);
+-- select shape from src/app/(portal)/messages/page.tsx (user client).
+
+CREATE TABLE IF NOT EXISTS public.contact_submissions (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  org_id uuid NOT NULL REFERENCES public.organizations(id) ON DELETE CASCADE,
+  name text NOT NULL,
+  email text,
+  phone text,
+  message text NOT NULL,
+  source text DEFAULT 'website',
+  status text NOT NULL DEFAULT 'new',
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_contact_submissions_org_created
+  ON public.contact_submissions(org_id, created_at DESC);
+
+-- ─── clients (legacy, guarded) ───────────────────────────────────────────────
+-- The live project already has a 1-row public.clients table; NO app code
+-- references it. Guards below create it only if missing and never alter
+-- existing data. On the live DB every statement here is a no-op except
+-- ENABLE ROW LEVEL SECURITY (closes anon access; service role unaffected).
+
+CREATE TABLE IF NOT EXISTS public.clients (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  name text,
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+
+ALTER TABLE public.clients ADD COLUMN IF NOT EXISTS name text;
+ALTER TABLE public.clients ADD COLUMN IF NOT EXISTS created_at timestamptz DEFAULT now();
+
+-- ─── Row Level Security ──────────────────────────────────────────────────────
+-- Admin (service role) client bypasses RLS: signup inserts, contact-route
+-- inserts, cron/agent routes. Policies below cover only what the USER client
+-- actually does, mirroring the org-membership subquery pattern used by
+-- 20260323_metric_tables (org_id IN (SELECT org_id FROM organization_members
+-- WHERE user_id = auth.uid())).
+
+ALTER TABLE public.organizations ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.organization_members ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.profiles ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.business_profiles ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.subscriptions ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.contact_submissions ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.clients ENABLE ROW LEVEL SECURITY;
+
+-- organizations: members can view their own org (getCurrentOrg selects *)
+DROP POLICY IF EXISTS "Org members can view their organization" ON public.organizations;
+CREATE POLICY "Org members can view their organization" ON public.organizations
+  FOR SELECT USING (
+    id IN (
+      SELECT org_id FROM public.organization_members WHERE user_id = auth.uid()
+    )
+  );
+
+-- organization_members: members can view all memberships of their org(s)
+-- (settings page team list selects user_id, role by org_id). Uses the
+-- SECURITY DEFINER helper to avoid self-referential policy recursion.
+DROP POLICY IF EXISTS "Members can view memberships of their orgs" ON public.organization_members;
+CREATE POLICY "Members can view memberships of their orgs" ON public.organization_members
+  FOR SELECT USING (org_id IN (SELECT public.user_org_ids()));
+
+-- profiles: own row (layout, dashboard, settings) + co-members' rows
+-- (settings team list selects profiles .in('id', memberUserIds))
+DROP POLICY IF EXISTS "Users can view own and co-member profiles" ON public.profiles;
+CREATE POLICY "Users can view own and co-member profiles" ON public.profiles
+  FOR SELECT USING (
+    id = auth.uid()
+    OR id IN (
+      SELECT user_id FROM public.organization_members
+      WHERE org_id IN (SELECT public.user_org_ids())
+    )
+  );
+
+-- business_profiles: org members read (settings/website/onboarding pages) and
+-- update (settings updateBusinessProfileAction uses the user client).
+-- Inserts happen via the admin client only (onboarding actions).
+DROP POLICY IF EXISTS "Org members can view business profile" ON public.business_profiles;
+CREATE POLICY "Org members can view business profile" ON public.business_profiles
+  FOR SELECT USING (
+    org_id IN (
+      SELECT org_id FROM public.organization_members WHERE user_id = auth.uid()
+    )
+  );
+
+DROP POLICY IF EXISTS "Org members can update business profile" ON public.business_profiles;
+CREATE POLICY "Org members can update business profile" ON public.business_profiles
+  FOR UPDATE USING (
+    org_id IN (
+      SELECT org_id FROM public.organization_members WHERE user_id = auth.uid()
+    )
+  );
+
+-- subscriptions: verbatim from the webhook route's DDL comment
+DROP POLICY IF EXISTS "Users can view their own subscription" ON public.subscriptions;
+CREATE POLICY "Users can view their own subscription" ON public.subscriptions
+  FOR SELECT USING (auth.uid() = user_id);
+
+-- contact_submissions: org members read their org's messages (messages page)
+DROP POLICY IF EXISTS "Org members can view contact_submissions" ON public.contact_submissions;
+CREATE POLICY "Org members can view contact_submissions" ON public.contact_submissions
+  FOR SELECT USING (
+    org_id IN (
+      SELECT org_id FROM public.organization_members WHERE user_id = auth.uid()
+    )
+  );
+
+-- clients: no policies on purpose — no code path reads it; service role only.

--- a/supabase/migrations/20260315000000_onboarding_oauth.sql
+++ b/supabase/migrations/20260315000000_onboarding_oauth.sql
@@ -91,7 +91,7 @@ CREATE POLICY "Users can update own onboarding" ON onboarding_progress
 CREATE POLICY "Org members can view oauth connections" ON oauth_connections
   FOR SELECT USING (
     org_id IN (
-      SELECT organization_id FROM organization_members WHERE user_id = auth.uid()
+      SELECT org_id FROM organization_members WHERE user_id = auth.uid()
     )
   );
 
@@ -99,6 +99,6 @@ CREATE POLICY "Org members can view oauth connections" ON oauth_connections
 CREATE POLICY "Org members can manage oauth connections" ON oauth_connections
   FOR ALL USING (
     org_id IN (
-      SELECT organization_id FROM organization_members WHERE user_id = auth.uid()
+      SELECT org_id FROM organization_members WHERE user_id = auth.uid()
     )
   );

--- a/supabase/migrations/20260728000000_report_share_tokens.sql
+++ b/supabase/migrations/20260728000000_report_share_tokens.sql
@@ -1,0 +1,18 @@
+-- ─── Report share tokens (public no-login report links) ──────────────────────
+-- Adds a nullable share_token to reports. When set, the report is reachable
+-- read-only at /r/[token] with no login. Tokens are generated application-side
+-- (crypto.randomUUID) via POST /api/reports/[reportId]/share and revoked by
+-- setting the column back to NULL (DELETE on the same route).
+--
+-- No RLS change is needed: anon/user clients never query by share_token.
+-- The public page looks the token up with the service-role client (bypasses
+-- RLS, server-only), so unshared reports stay invisible to the outside world.
+
+ALTER TABLE public.reports
+  ADD COLUMN IF NOT EXISTS share_token text;
+
+-- Partial unique index: enforces token uniqueness AND serves as the lookup
+-- index for /r/[token]. NULLs (unshared reports) are excluded.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_reports_share_token
+  ON public.reports(share_token)
+  WHERE share_token IS NOT NULL;


### PR DESCRIPTION
## What

Each client report can now be shared at an unguessable public URL, no login required.

- **Migration** `supabase/migrations/20260728000000_report_share_tokens.sql`: adds nullable `reports.share_token` (text) with a partial unique index (serves as both uniqueness guard and lookup index). NULL = not shared. No RLS change needed: public lookups go through the service-role client only.
- **Public page `/r/[token]`**: server component, fetches by `share_token` via the service-role client (server-only), renders the report read-only in the portal's existing style (summary, metric cards with trend badges, highlights), plain-English labels, mobile-friendly, `robots: noindex`, `force-dynamic` so revoked tokens 404 immediately. Unknown token = 404.
- **Middleware**: `/r/*` exempt from the login redirect and the onboarding-completeness check.
- **API `POST/DELETE /api/reports/[reportId]/share`**: portal-session auth; the report is loaded with the user's session client (RLS + explicit org filter), then the token write happens via the admin client. POST is idempotent (returns the existing link if one exists), token = `crypto.randomUUID()`. DELETE revokes.
- **Reports modal**: the Share button now generates the link and copies it to the clipboard.

## Added: base-schema migration (the portal was never wired to a real DB)

While preparing to run the share-token migration we found the live Supabase project is **empty** (only a legacy 1-row `clients` table) and **no migration creates the base tables** — every existing migration references `organizations(id)`, which was never created anywhere. This PR now also ships:

- **`supabase/migrations/20260314000000_base_schema.sql`** (timestamped before the other three so the chain orders correctly): creates `organizations`, `organization_members` (the membership table `getCurrentOrgId()` reads: `org_id`/`user_id`/`role`, one membership per user enforced with a unique index because every lookup uses `.single()`), `profiles`, `business_profiles`, `subscriptions` (verbatim from the DDL comment in the Stripe webhook route), `contact_submissions`, and a fully guarded legacy `clients` table (`CREATE TABLE IF NOT EXISTS` + `ADD COLUMN IF NOT EXISTS`, so the existing live row survives untouched). RLS enabled on everything; policies mirror the existing metric-tables org-membership subquery pattern, plus a `SECURITY DEFINER user_org_ids()` helper to avoid self-referential policy recursion on `organization_members`. The file is fully idempotent.
- **Fix in `20260315000000_onboarding_oauth.sql`**: its two `oauth_connections` policies selected `organization_id` from `organization_members` — a column that exists nowhere (app code and `20260323` both use `org_id`). The migration chain could never have applied as written; two-word fix.
- **`supabase/APPLY-ORDER.md`**: exact apply order for all 4 migrations in the SQL editor (project `btwrcfzphkwrvcqoyhym`), per-file idempotency status, and notes (clients RLS lockdown, service-role vs user-client access, known webhook client gap).

FK sanity check: every `REFERENCES` target across the 4 files is either `auth.users(id)` or a table created earlier in the chain (all point at `organizations(id)`, the first table in the base file).

## Verification

- `npx tsc --noEmit`: no new errors (the two pre-existing errors in `settings/__tests__/actions.test.ts` are identical on main).
- `npm run build`: green; `/r/[token]` and `/api/reports/[reportId]/share` both registered. Re-verified after the base-schema commit (SQL/docs only, no app code changed).

## Before merge/deploy

Apply the migrations in the Supabase SQL editor (project `btwrcfzphkwrvcqoyhym`) **in the order given in `supabase/APPLY-ORDER.md`** — base schema first, share-token last. The `share_token` column must exist before this code deploys, otherwise the share endpoint 500s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KVKk1BeDSzkffUa3xkNXA7