### PR TITLE
Monthly report cron: auto-generate tokenized client reports

### DIFF
--- a/src/app/api/cron/monthly-reports/route.ts
+++ b/src/app/api/cron/monthly-reports/route.ts
@@ -1,0 +1,461 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { randomUUID } from 'crypto'
+import { createAdminClient } from '@/lib/supabase/admin'
+import { ops, flush } from '@/lib/logger'
+
+export const runtime = 'nodejs'
+export const dynamic = 'force-dynamic'
+export const maxDuration = 60
+
+/**
+ * GET /api/cron/monthly-reports
+ *
+ * Runs on the 1st of each month (vercel.json). For every org whose
+ * business_profiles.reports_enabled is true (i.e. the PAYING book — the flag
+ * defaults false, so non-paying Lovable sites never get report rows):
+ *
+ *   1. Aggregates the PRIOR calendar month from the metric tables via the
+ *      SECTION_BUILDERS registry below — each metric table (analytics, ads,
+ *      seo, gbp) is one builder; a section only contributes numbers when it
+ *      has rows, and unwired sections are named honestly in the summary.
+ *      Adding a data source later (e.g. Meta ads for Triple clients) = add a
+ *      builder, no other changes.
+ *   2. Inserts a reports row (report_type 'monthly') with a share_token, so
+ *      the report is immediately reachable at /r/<token> with no login.
+ *      Idempotent: if a monthly report for that org+period already exists it
+ *      is NOT regenerated (a missing share_token is backfilled so the digest
+ *      always has a link).
+ *   3. After all orgs: sends ONE digest email to the owner
+ *      (joseph@skooped.io) listing each client and its /r/<token> link.
+ *      Clients are NEVER emailed by this route. Email failure (missing/stale
+ *      RESEND_API_KEY included) is logged and does not fail the run.
+ *
+ * Auth: Vercel cron convention — Authorization: Bearer CRON_SECRET, or the
+ * x-vercel-cron header (same pattern as the other cron routes here).
+ */
+
+// ─── Auth ────────────────────────────────────────────────────────────────────
+
+function verifyCron(request: NextRequest): boolean {
+  if (request.headers.get('x-vercel-cron')) return true
+  const secret = request.headers.get('authorization')?.replace('Bearer ', '')
+  const cronSecret = process.env.CRON_SECRET
+  if (!cronSecret) return process.env.NODE_ENV === 'development'
+  return secret === cronSecret
+}
+
+// ─── Shared helpers ──────────────────────────────────────────────────────────
+
+interface MetricRow {
+  org_id: string
+  date: string
+  [key: string]: unknown
+}
+
+function sum(rows: MetricRow[], field: string): number {
+  return rows.reduce((acc, r) => acc + (Number(r[field]) || 0), 0)
+}
+
+function avg(rows: MetricRow[], field: string): number {
+  if (rows.length === 0) return 0
+  return sum(rows, field) / rows.length
+}
+
+function pctChange(current: number, previous: number): number {
+  if (previous === 0) return current > 0 ? 100 : 0
+  return Math.round(((current - previous) / previous) * 100)
+}
+
+function fmt(n: number): string {
+  return n.toLocaleString('en-US')
+}
+
+// ─── Section builders (one per metric table — the extension point) ───────────
+
+interface SectionOutput {
+  /** Merged into reports.metrics. Keys match what /r/[token] renders. */
+  metrics: Record<string, number>
+  /** Sentences for reports.highlights. */
+  highlights: string[]
+  /** Sentence fragment(s) for the summary. */
+  summaryLines: string[]
+}
+
+interface SectionBuilder {
+  key: string
+  table: string
+  /** Human name used in the "not yet connected" note when the table is empty. */
+  label: string
+  build: (rows: MetricRow[], prevRows: MetricRow[]) => SectionOutput
+}
+
+const SECTION_BUILDERS: SectionBuilder[] = [
+  {
+    key: 'analytics',
+    table: 'analytics_metrics',
+    label: 'website analytics',
+    build: (rows, prevRows) => {
+      const sessions = sum(rows, 'sessions')
+      const pageviews = sum(rows, 'pageviews')
+      const prevSessions = sum(prevRows, 'sessions')
+      const sessionsChange = prevRows.length > 0 ? pctChange(sessions, prevSessions) : null
+
+      const line =
+        `${fmt(sessions)} website visits and ${fmt(pageviews)} page views` +
+        (sessionsChange !== null
+          ? ` (visits ${sessionsChange >= 0 ? 'up' : 'down'} ${Math.abs(sessionsChange)}% vs the month before)`
+          : '')
+
+      const highlights: string[] = []
+      if (sessionsChange !== null && sessionsChange > 0) {
+        highlights.push(`Website visits up ${sessionsChange}% month-over-month`)
+      }
+      if (sessionsChange !== null && sessionsChange < 0) {
+        highlights.push(`Website visits down ${Math.abs(sessionsChange)}% month-over-month`)
+      }
+
+      return {
+        metrics: {
+          sessions,
+          pageviews,
+          ...(sessionsChange !== null ? { sessions_change_pct: sessionsChange } : {}),
+        },
+        highlights,
+        summaryLines: [line],
+      }
+    },
+  },
+  {
+    key: 'ads',
+    table: 'ads_metrics',
+    label: 'ads performance',
+    build: (rows, prevRows) => {
+      const spend = Math.round(sum(rows, 'total_spend') * 100) / 100
+      const clicks = sum(rows, 'total_clicks')
+      const impressions = sum(rows, 'total_impressions')
+      const conversions = sum(rows, 'total_conversions')
+      const prevSpend = sum(prevRows, 'total_spend')
+      const spendChange = prevRows.length > 0 ? pctChange(spend, prevSpend) : null
+
+      const parts = [`$${spend.toFixed(2)} ad spend`, `${fmt(clicks)} ad clicks`]
+      if (impressions > 0) parts.push(`${fmt(impressions)} impressions`)
+      if (conversions > 0) parts.push(`${fmt(conversions)} conversions`)
+
+      return {
+        metrics: {
+          ad_spend: spend,
+          ad_clicks: clicks,
+          ad_impressions: impressions,
+          ad_conversions: conversions,
+          ...(spendChange !== null ? { ad_spend_change_pct: spendChange } : {}),
+        },
+        highlights: conversions > 0 ? [`${fmt(conversions)} conversions from ads`] : [],
+        summaryLines: [parts.join(', ')],
+      }
+    },
+  },
+  {
+    key: 'seo',
+    table: 'seo_metrics',
+    label: 'Google Search data',
+    build: (rows, prevRows) => {
+      const clicks = sum(rows, 'total_clicks')
+      const impressions = sum(rows, 'total_impressions')
+      const position = avg(rows, 'avg_position')
+      const prevClicks = sum(prevRows, 'total_clicks')
+      const prevPosition = avg(prevRows, 'avg_position')
+      const clicksChange = prevRows.length > 0 ? pctChange(clicks, prevClicks) : null
+      const positionChange =
+        prevRows.length > 0 ? Math.round((prevPosition - position) * 10) / 10 : null
+
+      return {
+        metrics: {
+          clicks,
+          impressions,
+          avg_position: Math.round(position * 10) / 10,
+          ...(clicksChange !== null ? { clicks_change_pct: clicksChange } : {}),
+          ...(positionChange !== null ? { position_change: positionChange } : {}),
+        },
+        highlights:
+          clicksChange !== null && clicksChange > 0
+            ? [`Google Search clicks up ${clicksChange}% month-over-month`]
+            : [],
+        summaryLines: [`${fmt(clicks)} clicks from Google Search`],
+      }
+    },
+  },
+  {
+    key: 'gbp',
+    table: 'gbp_metrics',
+    label: 'Google Business Profile',
+    build: (rows) => {
+      const phoneCalls = sum(rows, 'phone_calls')
+      const newReviews = sum(rows, 'new_reviews')
+
+      const parts: string[] = []
+      if (phoneCalls > 0) parts.push(`${fmt(phoneCalls)} phone calls from Google`)
+      if (newReviews > 0) parts.push(`${fmt(newReviews)} new Google reviews`)
+
+      return {
+        metrics: { phone_calls: phoneCalls, new_reviews: newReviews },
+        highlights:
+          newReviews > 0
+            ? [`${fmt(newReviews)} new Google review${newReviews > 1 ? 's' : ''}`]
+            : [],
+        summaryLines: parts.length > 0 ? [parts.join(', ')] : [],
+      }
+    },
+  },
+]
+
+// ─── Digest email (owner only — clients are never emailed here) ──────────────
+
+const OWNER_EMAIL = 'joseph@skooped.io'
+
+interface DigestEntry {
+  name: string
+  plan: string | null
+  url: string
+  status: 'generated' | 'existing'
+  summary: string
+}
+
+async function sendOwnerDigest(period: string, entries: DigestEntry[]): Promise<boolean> {
+  const apiKey = process.env.RESEND_API_KEY
+  if (!apiKey) {
+    console.warn('[monthly-reports] RESEND_API_KEY not set — skipping owner digest')
+    return false
+  }
+
+  const rowsHtml = entries
+    .map(
+      (e) => `
+      <tr>
+        <td style="padding:8px 12px;border-bottom:1px solid #eee">
+          <strong>${e.name}</strong>${e.plan ? ` <span style="color:#999;font-size:12px">(${e.plan})</span>` : ''}
+          ${e.status === 'existing' ? ' <span style="color:#999;font-size:12px">— already existed</span>' : ''}
+          <br><span style="color:#666;font-size:12px">${e.summary}</span>
+          <br><a href="${e.url}" style="color:#D94A7A;font-size:13px">${e.url}</a>
+        </td>
+      </tr>`
+    )
+    .join('')
+
+  const html = `
+  <div style="font-family:sans-serif;max-width:640px;margin:0 auto">
+    <h2 style="color:#361C24">Monthly reports generated — ${period}</h2>
+    <p style="color:#666;font-size:13px">${entries.length} client report${entries.length === 1 ? '' : 's'}. Links are public (tokenized, no login). Nothing has been sent to clients — forward or paste links as you see fit.</p>
+    <table style="width:100%;border-collapse:collapse">${rowsHtml}</table>
+  </div>`
+
+  try {
+    const res = await fetch('https://api.resend.com/emails', {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        from: 'Skooped <reports@skooped.io>',
+        to: [OWNER_EMAIL],
+        subject: `Monthly client reports ready — ${period} (${entries.length} client${entries.length === 1 ? '' : 's'})`,
+        html,
+      }),
+    })
+    if (!res.ok) {
+      console.error(`[monthly-reports] Resend responded ${res.status} — digest not sent`)
+    }
+    return res.ok
+  } catch (err) {
+    console.error('[monthly-reports] Resend request failed:', err)
+    return false
+  }
+}
+
+// ─── Route ───────────────────────────────────────────────────────────────────
+
+export async function GET(request: NextRequest) {
+  if (!verifyCron(request)) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const supabase = createAdminClient()
+  ops.info('system', 'cron.monthly_reports.started', 'started')
+
+  // Prior calendar month (UTC), plus the month before it for comparisons.
+  const now = new Date()
+  const y = now.getUTCFullYear()
+  const m = now.getUTCMonth()
+  const iso = (d: Date) => d.toISOString().split('T')[0]
+  const periodStart = iso(new Date(Date.UTC(y, m - 1, 1)))
+  const periodEnd = iso(new Date(Date.UTC(y, m, 0)))
+  const prevStart = iso(new Date(Date.UTC(y, m - 2, 1)))
+  const prevEnd = iso(new Date(Date.UTC(y, m - 1, 0)))
+  const periodLabel = new Date(Date.UTC(y, m - 1, 1)).toLocaleDateString('en-US', {
+    month: 'long',
+    year: 'numeric',
+    timeZone: 'UTC',
+  })
+
+  // Paying book only: reports_enabled defaults false and is flipped on per client.
+  const { data: profiles, error: profilesError } = await supabase
+    .from('business_profiles')
+    .select('org_id, business_name, plan, organizations(name)')
+    .eq('reports_enabled', true)
+
+  if (profilesError) {
+    ops.error('system', 'cron.monthly_reports', profilesError.message, 'unknown')
+    await flush()
+    return NextResponse.json({ error: 'Failed to load report-enabled orgs' }, { status: 500 })
+  }
+
+  if (!profiles || profiles.length === 0) {
+    await flush()
+    return NextResponse.json({ message: 'No orgs with reports_enabled', generated: 0 })
+  }
+
+  const digest: DigestEntry[] = []
+  let generated = 0
+  let skipped = 0
+  let failed = 0
+
+  for (const profile of profiles) {
+    const orgId = profile.org_id as string
+    const org = profile.organizations as unknown as { name: string } | null
+    const name = org?.name || (profile.business_name as string) || 'Unknown client'
+    const plan = (profile.plan as string | null) ?? null
+
+    try {
+      // Idempotency: one monthly report per org+period.
+      const { data: existing } = await supabase
+        .from('reports')
+        .select('id, share_token, summary')
+        .eq('org_id', orgId)
+        .eq('report_type', 'monthly')
+        .eq('period_start', periodStart)
+        .maybeSingle()
+
+      if (existing) {
+        let token = existing.share_token as string | null
+        if (!token) {
+          // Backfill a token so the digest always carries a working link.
+          token = randomUUID()
+          await supabase.from('reports').update({ share_token: token }).eq('id', existing.id)
+        }
+        digest.push({
+          name,
+          plan,
+          url: `https://app.skooped.io/r/${token}`,
+          status: 'existing',
+          summary: (existing.summary as string | null) ?? '',
+        })
+        skipped++
+        continue
+      }
+
+      // Run every registered section builder over the prior month.
+      const metrics: Record<string, number> = {}
+      const highlights: string[] = []
+      const summaryLines: string[] = []
+      const notWired: string[] = []
+
+      for (const builder of SECTION_BUILDERS) {
+        const [curRes, prevRes] = await Promise.all([
+          supabase
+            .from(builder.table)
+            .select('*')
+            .eq('org_id', orgId)
+            .gte('date', periodStart)
+            .lte('date', periodEnd),
+          supabase
+            .from(builder.table)
+            .select('*')
+            .eq('org_id', orgId)
+            .gte('date', prevStart)
+            .lte('date', prevEnd),
+        ])
+
+        const rows = (curRes.data ?? []) as MetricRow[]
+        const prevRows = (prevRes.data ?? []) as MetricRow[]
+
+        if (rows.length === 0) {
+          notWired.push(builder.label)
+          continue
+        }
+
+        const out = builder.build(rows, prevRows)
+        Object.assign(metrics, out.metrics)
+        highlights.push(...out.highlights)
+        summaryLines.push(...out.summaryLines)
+      }
+
+      // Honest plain-English summary: numbers we have, and what isn't wired.
+      let summary: string
+      if (summaryLines.length > 0) {
+        summary = `${periodLabel}: ${summaryLines.join('. ')}.`
+        if (notWired.length > 0) {
+          summary += ` Not yet connected: ${notWired.join(', ')} — those tiles will show zero until wired up.`
+        }
+      } else {
+        summary = `${periodLabel}: no tracking data was collected for this period yet (${notWired.join(', ')} not connected). Numbers will appear once data collection is wired up.`
+      }
+
+      const shareToken = randomUUID()
+      const { error: insertError } = await supabase.from('reports').insert({
+        org_id: orgId,
+        report_type: 'monthly',
+        period_start: periodStart,
+        period_end: periodEnd,
+        summary,
+        metrics,
+        highlights,
+        share_token: shareToken,
+      })
+
+      if (insertError) {
+        console.error(`[monthly-reports] ${name}: insert failed:`, insertError.message)
+        failed++
+        continue
+      }
+
+      await supabase.from('agent_activity').insert({
+        org_id: orgId,
+        agent: 'riley',
+        action_type: 'report_generated',
+        description: `Monthly performance report generated (${periodLabel})`,
+        metadata: { period_start: periodStart, period_end: periodEnd, report_type: 'monthly' },
+      })
+
+      digest.push({
+        name,
+        plan,
+        url: `https://app.skooped.io/r/${shareToken}`,
+        status: 'generated',
+        summary,
+      })
+      generated++
+      console.log(`[monthly-reports] ${name}: monthly report generated`)
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : 'Unknown error'
+      console.error(`[monthly-reports] ${name}: failed:`, msg)
+      failed++
+    }
+  }
+
+  // One owner digest, never client emails. Failure logged, run still succeeds.
+  const emailSent = digest.length > 0 ? await sendOwnerDigest(periodLabel, digest) : false
+
+  ops.info('system', 'cron.monthly_reports.completed', 'completed', {
+    metadata: { generated, skipped, failed, email_sent: emailSent, period: periodLabel },
+  })
+  await flush()
+
+  return NextResponse.json({
+    period: { start: periodStart, end: periodEnd },
+    generated,
+    skipped,
+    failed,
+    email_sent: emailSent,
+    reports: digest.map((d) => ({ name: d.name, status: d.status, url: d.url })),
+  })
+}

--- a/src/app/api/ingest/analytics/route.ts
+++ b/src/app/api/ingest/analytics/route.ts
@@ -1,0 +1,144 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { z } from 'zod'
+import { createAdminClient } from '@/lib/supabase/admin'
+import { ops, flush } from '@/lib/logger'
+
+export const runtime = 'nodejs'
+export const dynamic = 'force-dynamic'
+export const maxDuration = 60
+
+/**
+ * POST /api/ingest/analytics
+ *
+ * Push-path for site analytics that can't be pulled server-side (Lovable has
+ * no public REST analytics API as of 2026-07). An external writer — e.g. the
+ * local monthly routine reading Lovable analytics via MCP — POSTs daily rows
+ * here and they land in analytics_metrics, keyed (org_id, date), which the
+ * monthly report cron then aggregates.
+ *
+ * Auth: Authorization: Bearer <SERVICE_API_KEY>. If the env var is not set the
+ * endpoint is disabled (503) — it never falls open.
+ *
+ * Body: a single row or an array of rows:
+ *   {
+ *     org_slug:  "gunns-fencing",       // organizations.slug
+ *     date:      "2026-07-15",          // YYYY-MM-DD
+ *     sessions:  12,
+ *     pageviews: 34,
+ *     users:     10,                    // optional
+ *     bounce_rate: 41.2,               // optional, percent
+ *     avg_session_duration: 62.5,      // optional, seconds
+ *     sources:   [{ source: "google", sessions: 8 }],  // optional, stored as traffic_sources
+ *     top_pages: [{ path: "/", pageviews: 20 }]        // optional
+ *   }
+ *
+ * Upserts on (org_id, date) — re-posting a day overwrites it (idempotent).
+ * Unknown slugs are reported back, not treated as a hard failure, so one bad
+ * row doesn't sink a batch.
+ */
+
+const ingestRowSchema = z.object({
+  org_slug: z.string().min(1),
+  date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/, 'date must be YYYY-MM-DD'),
+  sessions: z.number().int().nonnegative().default(0),
+  pageviews: z.number().int().nonnegative().default(0),
+  users: z.number().int().nonnegative().optional(),
+  bounce_rate: z.number().min(0).max(100).optional(),
+  avg_session_duration: z.number().nonnegative().optional(),
+  sources: z.array(z.unknown()).default([]),
+  top_pages: z.array(z.unknown()).default([]),
+})
+
+const ingestBodySchema = z.union([ingestRowSchema, z.array(ingestRowSchema).min(1).max(500)])
+
+function verifyServiceKey(request: NextRequest): boolean {
+  const serviceKey = process.env.SERVICE_API_KEY
+  if (!serviceKey) return false
+  const provided = request.headers.get('authorization')?.replace('Bearer ', '')
+  return provided === serviceKey
+}
+
+export async function POST(request: NextRequest) {
+  if (!process.env.SERVICE_API_KEY) {
+    return NextResponse.json(
+      { error: 'Ingest disabled: SERVICE_API_KEY is not configured' },
+      { status: 503 }
+    )
+  }
+  if (!verifyServiceKey(request)) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  let body: unknown
+  try {
+    body = await request.json()
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 })
+  }
+
+  const parsed = ingestBodySchema.safeParse(body)
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: 'Validation failed', details: parsed.error.flatten() },
+      { status: 400 }
+    )
+  }
+
+  const rows = Array.isArray(parsed.data) ? parsed.data : [parsed.data]
+  const supabase = createAdminClient()
+
+  // Resolve org slugs → ids in one query
+  const slugs = Array.from(new Set(rows.map((r) => r.org_slug)))
+  const { data: orgs, error: orgError } = await supabase
+    .from('organizations')
+    .select('id, slug')
+    .in('slug', slugs)
+
+  if (orgError) {
+    ops.error('system', 'ingest.analytics', orgError.message, 'unknown')
+    await flush()
+    return NextResponse.json({ error: 'Failed to resolve organizations' }, { status: 500 })
+  }
+
+  const orgBySlug = new Map((orgs ?? []).map((o) => [o.slug as string, o.id as string]))
+  const unknownSlugs = slugs.filter((s) => !orgBySlug.has(s))
+
+  const upsertRows = rows
+    .filter((r) => orgBySlug.has(r.org_slug))
+    .map((r) => ({
+      org_id: orgBySlug.get(r.org_slug)!,
+      date: r.date,
+      sessions: r.sessions,
+      pageviews: r.pageviews,
+      ...(r.users !== undefined ? { users: r.users } : {}),
+      ...(r.bounce_rate !== undefined ? { bounce_rate: r.bounce_rate } : {}),
+      ...(r.avg_session_duration !== undefined
+        ? { avg_session_duration: r.avg_session_duration }
+        : {}),
+      traffic_sources: r.sources,
+      top_pages: r.top_pages,
+      // Marks the writer; distinguishes pushed rows from GA4-synced ones.
+      property_id: 'ingest',
+    }))
+
+  let upserted = 0
+  if (upsertRows.length > 0) {
+    const { error } = await supabase
+      .from('analytics_metrics')
+      .upsert(upsertRows, { onConflict: 'org_id,date' })
+
+    if (error) {
+      ops.error('system', 'ingest.analytics', error.message, 'unknown')
+      await flush()
+      return NextResponse.json({ error: 'Upsert failed', details: error.message }, { status: 500 })
+    }
+    upserted = upsertRows.length
+  }
+
+  ops.info('system', 'ingest.analytics', 'completed', {
+    metadata: { upserted, unknown_slugs: unknownSlugs },
+  })
+  await flush()
+
+  return NextResponse.json({ upserted, unknown_slugs: unknownSlugs })
+}

--- a/supabase/SEED-CLIENTS.sql
+++ b/supabase/SEED-CLIENTS.sql
@@ -1,0 +1,123 @@
+-- ============================================================================
+-- SEED-CLIENTS.sql — the paying Skooped book (2026-07)
+--
+-- NOT run automatically. Review, then paste into the Supabase SQL Editor
+-- (project btwrcfzphkwrvcqoyhym) AFTER 20260729000000_report_cron.sql.
+--
+-- Upserts organizations + business_profiles for every PAYING subscription
+-- client with reports_enabled = true, which is what the monthly report cron
+-- keys off. Non-paying Lovable sites are deliberately absent: reports_enabled
+-- defaults false, so they never get report rows or share links.
+--
+-- Idempotent: safe to re-run. Org matched on slug; profile matched on org_id.
+-- Existing profile fields other than plan / reports_enabled /
+-- lovable_project_id / business_name are left untouched.
+-- ============================================================================
+
+-- ─── Gray Skies Therapy (single) ─────────────────────────────────────────────
+WITH org AS (
+  INSERT INTO public.organizations (name, slug)
+  VALUES ('Gray Skies Therapy', 'gray-skies-therapy')
+  ON CONFLICT (slug) DO UPDATE SET name = EXCLUDED.name
+  RETURNING id
+)
+INSERT INTO public.business_profiles (org_id, business_name, plan, reports_enabled, lovable_project_id)
+SELECT id, 'Gray Skies Therapy', 'single', true, 'b8a89d2a-4abc-4db3-b536-23065d94cf09' FROM org
+ON CONFLICT (org_id) DO UPDATE SET
+  plan = EXCLUDED.plan,
+  reports_enabled = EXCLUDED.reports_enabled,
+  lovable_project_id = EXCLUDED.lovable_project_id;
+
+-- ─── Gunn's Fencing (triple — ads sections will light up once ads_metrics has rows) ─
+WITH org AS (
+  INSERT INTO public.organizations (name, slug)
+  VALUES ('Gunn''s Fencing', 'gunns-fencing')
+  ON CONFLICT (slug) DO UPDATE SET name = EXCLUDED.name
+  RETURNING id
+)
+INSERT INTO public.business_profiles (org_id, business_name, plan, reports_enabled, lovable_project_id)
+SELECT id, 'Gunn''s Fencing', 'triple', true, '04933a99-0ce5-4241-be2e-bc0e1f417015' FROM org
+ON CONFLICT (org_id) DO UPDATE SET
+  plan = EXCLUDED.plan,
+  reports_enabled = EXCLUDED.reports_enabled,
+  lovable_project_id = EXCLUDED.lovable_project_id;
+
+-- ─── Southern Door Pros (single) ─────────────────────────────────────────────
+WITH org AS (
+  INSERT INTO public.organizations (name, slug)
+  VALUES ('Southern Door Pros', 'southern-door-pros')
+  ON CONFLICT (slug) DO UPDATE SET name = EXCLUDED.name
+  RETURNING id
+)
+INSERT INTO public.business_profiles (org_id, business_name, plan, reports_enabled, lovable_project_id)
+SELECT id, 'Southern Door Pros', 'single', true, 'cd9e1ea2-905d-4433-83ab-d5b46e074b5c' FROM org
+ON CONFLICT (org_id) DO UPDATE SET
+  plan = EXCLUDED.plan,
+  reports_enabled = EXCLUDED.reports_enabled,
+  lovable_project_id = EXCLUDED.lovable_project_id;
+
+-- ─── Affordable Elegance (single) ────────────────────────────────────────────
+WITH org AS (
+  INSERT INTO public.organizations (name, slug)
+  VALUES ('Affordable Elegance', 'affordable-elegance')
+  ON CONFLICT (slug) DO UPDATE SET name = EXCLUDED.name
+  RETURNING id
+)
+INSERT INTO public.business_profiles (org_id, business_name, plan, reports_enabled, lovable_project_id)
+SELECT id, 'Affordable Elegance', 'single', true, '31f5d335-471a-464a-a8b0-287fee85bcbc' FROM org
+ON CONFLICT (org_id) DO UPDATE SET
+  plan = EXCLUDED.plan,
+  reports_enabled = EXCLUDED.reports_enabled,
+  lovable_project_id = EXCLUDED.lovable_project_id;
+
+-- ─── Squishy Clean (single) ──────────────────────────────────────────────────
+WITH org AS (
+  INSERT INTO public.organizations (name, slug)
+  VALUES ('Squishy Clean', 'squishy-clean')
+  ON CONFLICT (slug) DO UPDATE SET name = EXCLUDED.name
+  RETURNING id
+)
+INSERT INTO public.business_profiles (org_id, business_name, plan, reports_enabled, lovable_project_id)
+SELECT id, 'Squishy Clean', 'single', true, '9a3744ee-28c8-479e-83f7-9dc54dd447af' FROM org
+ON CONFLICT (org_id) DO UPDATE SET
+  plan = EXCLUDED.plan,
+  reports_enabled = EXCLUDED.reports_enabled,
+  lovable_project_id = EXCLUDED.lovable_project_id;
+
+-- ─── Revamp Junk (single) ────────────────────────────────────────────────────
+WITH org AS (
+  INSERT INTO public.organizations (name, slug)
+  VALUES ('Revamp Junk', 'revamp-junk')
+  ON CONFLICT (slug) DO UPDATE SET name = EXCLUDED.name
+  RETURNING id
+)
+INSERT INTO public.business_profiles (org_id, business_name, plan, reports_enabled, lovable_project_id)
+SELECT id, 'Revamp Junk', 'single', true, '6b3d801c-fa77-4e92-9dcb-478b52b7f6cd' FROM org
+ON CONFLICT (org_id) DO UPDATE SET
+  plan = EXCLUDED.plan,
+  reports_enabled = EXCLUDED.reports_enabled,
+  lovable_project_id = EXCLUDED.lovable_project_id;
+
+-- ─── Rios Landscaping (single) ───────────────────────────────────────────────
+-- TODO: lovable_project_id unknown as of 2026-07-29 — fill in once identified
+-- (UPDATE public.business_profiles SET lovable_project_id = '<uuid>'
+--  WHERE org_id = (SELECT id FROM public.organizations WHERE slug = 'rios-landscaping');)
+WITH org AS (
+  INSERT INTO public.organizations (name, slug)
+  VALUES ('Rios Landscaping', 'rios-landscaping')
+  ON CONFLICT (slug) DO UPDATE SET name = EXCLUDED.name
+  RETURNING id
+)
+INSERT INTO public.business_profiles (org_id, business_name, plan, reports_enabled, lovable_project_id)
+SELECT id, 'Rios Landscaping', 'single', true, NULL FROM org
+ON CONFLICT (org_id) DO UPDATE SET
+  plan = EXCLUDED.plan,
+  reports_enabled = EXCLUDED.reports_enabled,
+  lovable_project_id = EXCLUDED.lovable_project_id;
+
+-- ─── Verify ──────────────────────────────────────────────────────────────────
+-- SELECT o.name, o.slug, bp.plan, bp.reports_enabled, bp.lovable_project_id
+-- FROM public.organizations o
+-- JOIN public.business_profiles bp ON bp.org_id = o.id
+-- WHERE bp.reports_enabled
+-- ORDER BY o.name;

--- a/supabase/migrations/20260729000000_report_cron.sql
+++ b/supabase/migrations/20260729000000_report_cron.sql
@@ -1,0 +1,25 @@
+-- ─── Monthly report cron: business_profiles flags ────────────────────────────
+-- Adds the fields the monthly report cron keys off:
+--   lovable_project_id — Lovable project UUID for the client's site (analytics
+--                        for it are pushed in via /api/ingest/analytics; Lovable
+--                        has no public REST analytics API as of 2026-07)
+--   plan               — Skooped plan ('single' | 'triple'); the report builder
+--                        uses it to decide which sections matter (ads for triple)
+--   reports_enabled    — ONLY orgs with true get monthly report rows/links.
+--                        Defaults false so non-paying orgs are excluded unless
+--                        explicitly flipped on (see supabase/SEED-CLIENTS.sql).
+-- Idempotent: safe to re-run.
+
+ALTER TABLE public.business_profiles
+  ADD COLUMN IF NOT EXISTS lovable_project_id text;
+
+ALTER TABLE public.business_profiles
+  ADD COLUMN IF NOT EXISTS plan text;
+
+ALTER TABLE public.business_profiles
+  ADD COLUMN IF NOT EXISTS reports_enabled boolean NOT NULL DEFAULT false;
+
+-- Partial index: the cron's single query is "all profiles with reports_enabled".
+CREATE INDEX IF NOT EXISTS idx_business_profiles_reports_enabled
+  ON public.business_profiles(org_id)
+  WHERE reports_enabled;

--- a/vercel.json
+++ b/vercel.json
@@ -1,26 +1,6 @@
 {
   "crons": [
     {
-      "path": "/api/cron/sync-all",
-      "schedule": "0 8 * * *"
-    },
-    {
-      "path": "/api/cron/token-health",
-      "schedule": "0 14 * * *"
-    },
-    {
-      "path": "/api/cron/site-health",
-      "schedule": "0 15 * * *"
-    },
-    {
-      "path": "/api/cron/generate-reports",
-      "schedule": "0 12 * * 1"
-    },
-    {
-      "path": "/api/cron/send-weekly-emails",
-      "schedule": "0 14 * * 1"
-    },
-    {
       "path": "/api/cron/monthly-reports",
       "schedule": "0 13 1 * *"
     }

--- a/vercel.json
+++ b/vercel.json
@@ -19,6 +19,10 @@
     {
       "path": "/api/cron/send-weekly-emails",
       "schedule": "0 14 * * 1"
+    },
+    {
+      "path": "/api/cron/monthly-reports",
+      "schedule": "0 13 1 * *"
     }
   ]
 }


### PR DESCRIPTION
## What

Zero-touch monthly client reports: a Vercel cron generates a tokenized report per paying client on the 1st of each month and emails Joseph (and ONLY Joseph) one digest of the /r/<token> links.

## How

- **`/api/cron/monthly-reports`** (GET, `CRON_SECRET` / `x-vercel-cron` guarded, scheduled `0 13 1 * *` in `vercel.json`): for each org with `business_profiles.reports_enabled = true`, aggregates the **prior calendar month** through a section-builder registry over `analytics_metrics`, `ads_metrics`, `seo_metrics`, `gbp_metrics` — one builder per metric table, so future sources (Meta/Google ads for Triple clients) are one new builder, not a rewrite. Composes an honest plain-English summary that names sections not yet wired, inserts a `reports` row (`report_type 'monthly'`, `share_token = randomUUID()`), **idempotent** per org+period (re-runs skip; missing tokens are backfilled). Then ONE Resend digest to joseph@skooped.io. Clients are never emailed. Missing/stale `RESEND_API_KEY` is logged and never fails the run.
- **`/api/ingest/analytics`** (POST, `Bearer SERVICE_API_KEY`, 503 when the env is unset): push-path fallback for Lovable site analytics. **Lovable has no public REST analytics API** (checked docs.lovable.dev 2026-07-29 — analytics is UI + MCP only), so an external writer (the approved local monthly routine) pushes `{org_slug, date, sessions, pageviews, sources, top_pages}` rows; upserts on `(org_id, date)`.
- **Migration `20260729000000_report_cron.sql`**: `business_profiles` + `lovable_project_id text`, `plan text`, `reports_enabled boolean NOT NULL DEFAULT false`, idempotent guards. Non-paying Lovable sites are excluded by default.
- **`supabase/SEED-CLIENTS.sql`** (review-only, NOT auto-run): upserts the 7 paying clients with `reports_enabled = true`, plans (`single`, Gunn's `triple`), Lovable project ids (Rios Landscaping id is a TODO).

## Verification

- `npm run build` green; both new routes registered
- `npx tsc --noEmit`: no errors in new code (2 pre-existing errors in `src/app/(portal)/settings/__tests__/actions.test.ts` exist on main unchanged)

## Not done here (deliberate)

- Migration + seed are not applied to the DB — run manually in the Supabase SQL editor (migration first, then seed after review)
- `SERVICE_API_KEY` needs to be added in Vercel env before the ingest path works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KVKk1BeDSzkffUa3xkNXA7